### PR TITLE
Fixed issue with .mp-result element

### DIFF
--- a/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
+++ b/src/MiniProfiler.Shared/ui/lib/MiniProfiler.ts
@@ -831,7 +831,7 @@ namespace StackExchange.Profiling {
             }
 
             return mp.jq(`
-  <div class="mp-result${(this.options.showTrivial ? 'show-trivial' : '')}${(this.options.showChildrenTime ? 'show-columns' : '')}">
+  <div class="mp-result${(this.options.showTrivial ? ' show-trivial' : '')}${(this.options.showChildrenTime ? ' show-columns' : '')}">
     <div class="mp-button" title="${encode(p.Name)}">
       <span class="mp-number">${duration(p.DurationMilliseconds)} <span class="mp-unit">ms</span></span>
       ${(p.HasDuplicateCustomTimings ? '<span class="mp-warning">!</span>' : '')}


### PR DESCRIPTION
Fixed issue with .mp-result class being joined with other classes as there is nothing to separate it.

![image](https://user-images.githubusercontent.com/8421443/41102273-5eda5dca-6a5e-11e8-8aeb-fbb96a6fded7.png)
